### PR TITLE
Heroku to run jar file

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: lein ring server-headless
+web: java -jar target/facebook-example-standalone.jar

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Check out the code to find out more. Also try sending "image" or "help" to your 
 	```
 	heroku config:set PAGE_ACCESS_TOKEN=your_page_access_token
 	heroku config:set VERIFY_TOKEN=your_verify_token
+	heroku config:set LEIN_BUILD_TASK='ring uberjar'
 	```
 
 5. In case you made any changes in your code after downloading the original repository you need to commit them with `git add .` in your command prompt to check-in your changes to Git Version Control and add a commit message with `git commit -m "updated my bot"`.


### PR DESCRIPTION
If I understand correctly, the Heroku startup command is not currently using the jar files.
For memory optimisation, It could be advisable to run the .jar file.

Relevant links:
https://devcenter.heroku.com/articles/clojure-support#uberjar
https://devcenter.heroku.com/articles/clojure-support#customizing-the-build

Note that the global var on Heroku needs to be changed otherwise Heroku will fallback to running `lein uberjar`. https://github.com/heroku/heroku-buildpack-clojure/blob/master/bin/compile#L31-L52