### PR TITLE
Quick replies + match ALL the things!

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/data.json "0.2.1"]
                  [org.clojure/core.async "0.3.443"]
+                 [org.clojure/core.match "0.3.0-alpha4"]
                  [compojure "1.5.1"]
                  [http-kit "2.2.0"]
                  [ring/ring-defaults "0.2.1"]

--- a/src/facebook_example/bot.clj
+++ b/src/facebook_example/bot.clj
@@ -6,7 +6,7 @@
             [fb-messenger.send :as facebook]
             [facebook-example.reaction :as reaction]))
 
-; Uncomment if you want to set a peristent menu in your bot:
+; Uncomment if you want to set a persistent menu in your bot:
 ; (facebook/set-messenger-profile
 ;      {:get_started {:payload "get-started"}
 ;       :persistent_menu [{:locale "default"
@@ -63,15 +63,15 @@
     (reaction/thank-for-attachment)))
 
 ; You should not need to touch the following code :)
-(defn postback? [messaging-event](contains? messaging-event :postback))
-(defn attachments? [messaging-event] (contains? (:message messaging-event) :attachments))
-(defn message? [messaging-event] (contains? messaging-event :message))
-
 (defn process-event [event]
   (match [event]
     ; The user `sender-id` has selected one quick-reply option
-    [{:message {:quick_reply quick-reply :text text} :sender {:id sender-id}}]
+    [{:message {:quick_reply quick-reply} :sender {:id sender-id}}]
     (on-quick-reply event)
+
+    ; The user `sender-id` has sent a text message
+    [{:message {:text text} :sender {:id sender-id}}]
+    (on-message event)
 
     ; The user `sender-id` has sent a file or sticker
     [{:message {:attachments attachments} :sender {:id sender-id}}]
@@ -82,7 +82,7 @@
     (on-postback event)
 
     :else
-    (on-message event)))
+    (println (str "Webhook received unknown messaging-event: " event))))
 
 (defn handle-message [messaging-event]
   (let [sender-id (get-in messaging-event [:sender :id])

--- a/src/facebook_example/bot.clj
+++ b/src/facebook_example/bot.clj
@@ -34,7 +34,7 @@
   (println event)
   (let [sender-id (get-in event [:sender :id])
         quick-reply (get-in event [:message :quick_reply])
-        quick-reply-payload (get-in event [:message :quick_reply :payload])]
+        quick-reply-payload (:payload quick-reply)]
     (cond
       (= quick-reply-payload "CLOJURE") (reaction/send-clojure-docs)
       (= quick-reply-payload "HEROKU") (reaction/send-heroku-instructions)
@@ -66,19 +66,19 @@
 (defn process-event [event]
   (match [event]
     ; The user `sender-id` has selected one quick-reply option
-    [{:message {:quick_reply quick-reply} :sender {:id sender-id}}]
+    [{:message {:quick_reply _}}]
     (on-quick-reply event)
 
     ; The user `sender-id` has sent a text message
-    [{:message {:text text} :sender {:id sender-id}}]
+    [{:message {:text _}}]
     (on-message event)
 
     ; The user `sender-id` has sent a file or sticker
-    [{:message {:attachments attachments} :sender {:id sender-id}}]
+    [{:message {:attachments _}}]
     (on-attachments event)
 
     ; The user `sender-id` has pressed a button for which a "postback" event has been defined
-    [{:postback {:payload postback} :sender {:id sender-id}}]
+    [{:postback {:payload _}}]
     (on-postback event)
 
     :else

--- a/src/facebook_example/bot.clj
+++ b/src/facebook_example/bot.clj
@@ -64,6 +64,7 @@
 
 ; You should not need to touch the following code :)
 (defn process-event [event]
+  ; The order of the matchers is important!
   (match [event]
     ; The user `sender-id` has selected one quick-reply option
     [{:message {:quick_reply _}}]

--- a/src/facebook_example/bot.clj
+++ b/src/facebook_example/bot.clj
@@ -1,6 +1,7 @@
 (ns facebook-example.bot
   (:gen-class)
   (:require [clojure.string :as string]
+            [clojure.core.match :refer [match]]
             [environ.core :refer [env]]
             [fb-messenger.send :as facebook]
             [facebook-example.reaction :as reaction]))
@@ -27,6 +28,17 @@
       (re-matches #"(?i)image" message-text) (reaction/some-image)
       ; If no rules apply echo the user's message-text input
       :else (reaction/echo message-text))))
+
+(defn on-quick-reply [event]
+  (println "on-quickreply event:")
+  (println event)
+  (let [sender-id (get-in event [:sender :id])
+        quick-reply (get-in event [:message :quick_reply])
+        quick-reply-payload (get-in event [:message :quick_reply :payload])]
+    (cond
+      (= quick-reply-payload "CLOJURE") (reaction/send-clojure-docs)
+      (= quick-reply-payload "HEROKU") (reaction/send-heroku-instructions)
+      :else (reaction/error))))
 
 (defn on-postback [event]
   (println "on-postback event:")
@@ -55,14 +67,25 @@
 (defn attachments? [messaging-event] (contains? (:message messaging-event) :attachments))
 (defn message? [messaging-event] (contains? messaging-event :message))
 
+(defn process-event [event]
+  (match [event]
+    ; The user `sender-id` has selected one quick-reply option
+    [{:message {:quick_reply quick-reply :text text} :sender {:id sender-id}}]
+    (on-quick-reply event)
+
+    ; The user `sender-id` has sent a file or sticker
+    [{:message {:attachments attachments} :sender {:id sender-id}}]
+    (on-attachments event)
+
+    ; The user `sender-id` has pressed a button for which a "postback" event has been defined
+    [{:postback {:payload postback} :sender {:id sender-id}}]
+    (on-postback event)
+
+    :else
+    (on-message event)))
+
 (defn handle-message [messaging-event]
   (let [sender-id (get-in messaging-event [:sender :id])
-        replies (cond
-                  (postback? messaging-event) (on-postback messaging-event)
-                  (message? messaging-event)
-                  (cond
-                    (attachments? messaging-event)  (on-attachments messaging-event)
-                    :else                           (on-message messaging-event))
-                  :else (println (str "Webhook received unknown messaging-event: " messaging-event)))]
+        replies (process-event messaging-event)]
     (doseq [message replies]
       (facebook/send-message sender-id message))))

--- a/src/facebook_example/reaction.clj
+++ b/src/facebook_example/reaction.clj
@@ -16,7 +16,7 @@
   [(templates/text-message "Sorry, I didn't get that! :(")])
 
 (defn thank-for-attachment []
-  [(templates/text-message "Thank you for your attachment")])
+  [(templates/text-message "Thank you for your attachment :)")])
 
 (defn help []
   [(templates/quick-replies-message "What do you need help with?"

--- a/src/facebook_example/reaction.clj
+++ b/src/facebook_example/reaction.clj
@@ -28,7 +28,7 @@
                                       :payload "HEROKU"}])])
 
 (defn send-clojure-docs []
-  [(templates/text-message "Find Clojure docs here:")])
+  [(templates/text-message "Find Clojure docs here: https://clojuredocs.org/")])
 
 (defn send-heroku-instructions []
-  [(templates/text-message "Find Heroku instructions here:")])
+  [(templates/text-message "Find Heroku instructions here: https://github.com/lemmings-io/02-facebook-example#deploying-to-heroku")])

--- a/src/facebook_example/reaction.clj
+++ b/src/facebook_example/reaction.clj
@@ -2,9 +2,6 @@
   (:gen-class)
   (:require [fb-messenger.templates :as templates]))
 
-(defn help []
-  [(templates/text-message "Hi there, happy to help :)")])
-
 (defn some-image []
   [(templates/image-message "https://upload.wikimedia.org/wikipedia/commons/e/ef/Tunturisopuli_Lemmus_Lemmus.jpg")])
 
@@ -20,3 +17,18 @@
 
 (defn thank-for-attachment []
   [(templates/text-message "Thank you for your attachment")])
+
+(defn help []
+  [(templates/quick-replies-message "What do you need help with?"
+                                    [{:content_type "text"
+                                      :title "Clojure"
+                                      :payload "CLOJURE"}
+                                     {:content_type "text"
+                                      :title "Heroku"
+                                      :payload "HEROKU"}])])
+
+(defn send-clojure-docs []
+  [(templates/text-message "Find Clojure docs here:")])
+
+(defn send-heroku-instructions []
+  [(templates/text-message "Find Heroku instructions here:")])


### PR DESCRIPTION
I added an example for quick-replies, which is triggered by typing "help".

I also the dispatcher with matchers as originally proposed https://github.com/lemmings-io/02-facebook-example/pull/15. However, the callbacks have been kept.

Ideally, everything below the warning ("You should not need to touch the following code :)") will not need to be modified and is quite isolated. That's why in my opinion we can go for a more concise version rather than keeping the more conventional `cond`.