### PR TITLE
update profiles.clj template indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A Facebook Messenger Bot Example in Clojure
 4. Provide your Facebook Page Access Token, Verify Token and Page Secret for local development by creating a file called `profiles.clj` in your working directory `<your-project-name>/profiles.clj`
 
 		{:dev {:env {:page-access-token "REPLACE"
-		   		   	 :verify-token "REPLACE"}}}
+		   		   	  :verify-token "REPLACE"}}}
 
 ### Starting the development environment
 


### PR DESCRIPTION
The :verify-token line was missing one space, causing incorrect parsing by parinfer.